### PR TITLE
Implementing Connected React Router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3880,6 +3880,14 @@
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
       "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
     },
+    "connected-react-router": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.8.0.tgz",
+      "integrity": "sha512-E64/6krdJM3Ag3MMmh2nKPtMbH15s3JQDuaYJvOVXzu6MbHbDyIvuwLOyhQIuP4Om9zqEfZYiVyflROibSsONg==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.4.1",
     "@testing-library/user-event": "^7.2.1",
+    "connected-react-router": "^6.8.0",
     "cross-env": "^7.0.2",
     "debounce": "^1.2.0",
     "enzyme": "^3.11.0",

--- a/src/app/containers/LoggedPagesWrapper/index.js
+++ b/src/app/containers/LoggedPagesWrapper/index.js
@@ -1,19 +1,17 @@
 import React from 'react';
 import {
-  BrowserRouter, Route, Switch,
+  Route, Switch,
 } from 'react-router-dom';
 import PrivateRoute from '../PrivateRouter';
 import { homeTitle, appTitle } from './components';
 import Template from '../Template';
 
 const LoggedPagesWrapper = () => (
-  <BrowserRouter>
-    <Switch>
-      <Route exact path="/" component={homeTitle} />
-      <Route exact path="/template" component={Template} />
-      <PrivateRoute exact path="/app" component={appTitle} />
-    </Switch>
-  </BrowserRouter>
+  <Switch>
+    <Route exact path="/" component={homeTitle} />
+    <Route exact path="/template" component={Template} />
+    <PrivateRoute exact path="/app" component={appTitle} />
+  </Switch>
 );
 
 export default LoggedPagesWrapper;

--- a/src/app/containers/LoggedPagesWrapper/tests/index.test.js
+++ b/src/app/containers/LoggedPagesWrapper/tests/index.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import {
-  BrowserRouter, Route, Switch,
+  Route, Switch,
 } from 'react-router-dom';
 import PrivateRoute from '../../PrivateRouter';
 import Template from '../../Template';
@@ -18,7 +18,6 @@ const renderedComponent = render();
 
 describe('<LoggesPagesWrapper />', () => {
   it('should render Wrapper correctly', () => {
-    expect(renderedComponent.find(BrowserRouter)).toHaveLength(1);
     expect(renderedComponent.find(Switch)).toHaveLength(1);
     expect(renderedComponent.find(Route)).toHaveLength(2);
     expect(renderedComponent.find(PrivateRoute)).toHaveLength(1);

--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,15 @@ import ReactDOM from 'react-dom';
 import { IntlProvider } from 'react-intl';
 import createMuiTheme from '@material-ui/core/styles/createMuiTheme';
 import { Provider } from 'react-redux';
+import { ConnectedRouter } from 'connected-react-router/immutable';
+import history from './utils/history';
 import ThemeProvider from './utils/Theme/ThemeProvider';
 import { theme } from './utils/Theme/theme';
 import App from './app/containers/App/index';
 import initializeStore from './reducer/initializeStore';
 
-const store = initializeStore();
+const initialState = {};
+const store = initializeStore(initialState, history);
 
 const MOUNT_NODE = document.getElementById('root');
 
@@ -16,7 +19,9 @@ ReactDOM.render(
   <IntlProvider locale="en">
     <ThemeProvider theme={createMuiTheme(theme)}>
       <Provider store={store}>
-        <App />
+        <ConnectedRouter history={history}>
+          <App />
+        </ConnectedRouter>
       </Provider>
     </ThemeProvider>
   </IntlProvider>,

--- a/src/reducer/initializeStore.js
+++ b/src/reducer/initializeStore.js
@@ -1,8 +1,10 @@
 import { createStore, compose, applyMiddleware } from 'redux';
-import { Map } from 'immutable';
+import { fromJS } from 'immutable';
 import thunk from 'redux-thunk';
 import { middleware as reduxPackMiddleware } from 'redux-pack';
+import { routerMiddleware } from 'connected-react-router/immutable';
 import createReducer from './rootReducer';
+
 
 // If Redux DevTools Extension is installed use it, otherwise use Redux compose
 
@@ -11,15 +13,14 @@ const composeEnhancers = (typeof window !== 'undefined'
   && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
   /* eslint-enable */
 
-const initializeStore = () => {
-  const middlewares = [thunk, reduxPackMiddleware];
+const initializeStore = (initialState = {}, history) => {
+  const middlewares = [thunk, reduxPackMiddleware, routerMiddleware(history)];
 
   const enhancers = [applyMiddleware(...middlewares)];
 
-  const initialState = Map({});
   const store = createStore(
-    createReducer,
-    initialState,
+    createReducer(),
+    fromJS(initialState),
     composeEnhancers(...enhancers),
   );
 

--- a/src/reducer/rootReducer.js
+++ b/src/reducer/rootReducer.js
@@ -1,4 +1,6 @@
 import { combineReducers } from 'redux-immutable';
+import { connectRouter } from 'connected-react-router/immutable';
+import history from '../utils/history';
 /**
  * @param {Object} - key/value of reducer functions
  */
@@ -6,7 +8,8 @@ import { combineReducers } from 'redux-immutable';
 // Define the Reducers that will always be present in the application
 const staticReducers = { };
 
-export const createReducer = (asyncReducers) => combineReducers({
+export const createReducer = (asyncReducers = {}) => combineReducers({
+  router: connectRouter(history),
   ...asyncReducers,
   ...staticReducers,
 });

--- a/src/reducer/tests/rootReducer.test.js
+++ b/src/reducer/tests/rootReducer.test.js
@@ -1,7 +1,10 @@
 import { combineReducers } from 'redux-immutable';
+import { connectRouter } from 'connected-react-router/immutable';
 import createReducer from '../rootReducer';
+import history from '../../utils/history';
 
 jest.mock('redux-immutable');
+jest.mock('connected-react-router/immutable');
 
 describe('rootReducer', () => {
   it('should call combineReducers with asyncReducers passed as prop', () => {
@@ -13,6 +16,7 @@ describe('rootReducer', () => {
     createReducer(asyncReducers);
 
     expect(combineReducers).toHaveBeenCalledWith({
+      route: connectRouter(history),
       ...asyncReducers,
       ...staticReducers,
     });

--- a/src/utils/history.js
+++ b/src/utils/history.js
@@ -1,0 +1,4 @@
+import { createBrowserHistory } from 'history';
+
+const history = createBrowserHistory();
+export default history;


### PR DESCRIPTION
### **WHY**

The connected-react-router library provides Redux bindings for React Router; for example, the application's history can be read from a Redux store and you can navigate to different routes in the application by dispatching actions to the store.

### **WHAT**

We are implementing connected-react-router library on our code, and also refactoring minors. 

