### PR TITLE
Changing i18n strategy

### DIFF
--- a/src/app/containers/LanguageProvider/index.js
+++ b/src/app/containers/LanguageProvider/index.js
@@ -8,16 +8,22 @@ import { DEFAULT_LOCALE } from './constants';
 
 import { makeSelectLocale } from './selectors';
 
-export const LanguageProvider = ({ locale, messages, children }) => (
-  <IntlProvider
-    locale={locale}
-    key={locale}
-    defaultLocale={DEFAULT_LOCALE}
-    messages={messages[locale]}
-  >
-    {React.Children.only(children)}
-  </IntlProvider>
-);
+export const LanguageProvider = ({ locale, messages, children }) => {
+  const mergedMessages = { ...messages[DEFAULT_LOCALE], ...messages[locale] };
+
+  return (
+    <IntlProvider
+      locale={locale}
+      key={locale}
+      defaultLocale={DEFAULT_LOCALE}
+      messages={mergedMessages}
+    >
+      {React.Children.only(children)}
+    </IntlProvider>
+
+  );
+};
+
 
 LanguageProvider.propTypes = {
   messages: PropTypes.shape({

--- a/src/app/containers/LoggedPagesWrapper/translations/pt.js
+++ b/src/app/containers/LoggedPagesWrapper/translations/pt.js
@@ -1,0 +1,5 @@
+import { templateMessages } from '../../Template/translations/pt';
+
+export const loggedPagesWrapperMessages = {
+  ...templateMessages,
+};

--- a/src/app/containers/Template/messages.js
+++ b/src/app/containers/Template/messages.js
@@ -5,6 +5,5 @@ export const scope = 'src.app.containers.Template';
 export default defineMessages({
   changeLocaleButton: {
     id: `${scope}.changeLocaleButton`,
-    defaultMessage: 'Mudar linguagem para EN',
   },
 });

--- a/src/app/containers/Template/translations/pt.js
+++ b/src/app/containers/Template/translations/pt.js
@@ -1,5 +1,5 @@
 import { scope } from '../messages';
 
 export const templateMessages = {
-  [`${scope}.changeLocaleButton`]: 'Change locale to EN',
+  [`${scope}.changeLocaleButton`]: 'Trocar Local para PT',
 };

--- a/src/translations/pt.js
+++ b/src/translations/pt.js
@@ -1,7 +1,7 @@
-/*
-  Due this language is the default language, MessageDescriptor returned by
-  defineMessage function of react intl library is enough to handle with messages of this
-  language.
-*/
+import {
+  loggedPagesWrapperMessages,
+} from '../app/containers/LoggedPagesWrapper/translations/pt';
 
-export const pt = {};
+export const pt = {
+  ...loggedPagesWrapperMessages,
+};


### PR DESCRIPTION
### **WHAT**

We are removing defaultMessage from defineMessages, in order to define what language is default on LanguageProvider component.